### PR TITLE
Fix: Order form submit doesn't work

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
Fixes Shift3#14

# Changes
1. Modify `OrderForm.menuItemChosen` to update the `order_item` state variable instead of `item`.

# Purpose:
The value of the menu select element is controlled by the `order_item` state variable. Therefore, the `onChange` event handler should update the `order_item` state variable with the new value.