### PR TITLE
Fix: Format order time correctly

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Template } from '../../components';
 import { SERVER_IP } from '../../private';
+import { toHHMMSSTimeString } from '../../utils';
 import './viewOrders.css';
 
 class ViewOrders extends Component {
@@ -33,7 +34,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {toHHMMSSTimeString(createdDate)}</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">

--- a/application/src/utils/index.js
+++ b/application/src/utils/index.js
@@ -1,0 +1,3 @@
+import { toHHMMSSTimeString } from './time';
+
+export { toHHMMSSTimeString };

--- a/application/src/utils/time.js
+++ b/application/src/utils/time.js
@@ -1,0 +1,6 @@
+/**
+ * Returns a time string formatted in hh:mm:ss format.
+ * 
+ * @param {Date} date - The date to format. 
+ */
+export const toHHMMSSTimeString = (date) => date.toTimeString().substring(0, 8);


### PR DESCRIPTION
Fixes Shift3#30.

Changes:
1. Create a utility function that returns a hh:mm:ss formatted time string from a date object.
2. Use the utility function in the ViewOrders component to properly format the order time as hh:mm:ss format.

Purpose:
The `toHHMMSSTimeString` utility function was created to decouple the the logic of converting a date object to a hh:mm:ss formatted time string from the ViewOrders component whose responsibility is rendering UI.