### PR TITLE
Feat: Route guarding

### DIFF
--- a/application/src/components/login/login-form/loginForm.js
+++ b/application/src/components/login/login-form/loginForm.js
@@ -8,16 +8,25 @@ const mapActionsToProps = dispatch => ({
   }
 })
 
+const mapStateToProps = (state) => ({
+  auth: state.auth,
+})
+
 class LoginForm extends Component {
   state = {
     email: "",
     password: "",
   }
 
+  componentDidUpdate() {
+    if (this.props.auth.token) {
+      this.props.onLogin();
+    }
+  }
+
   login(e) {
     e.preventDefault();
     this.props.commenceLogin(this.state.email, this.state.password);
-    this.props.onLogin();
   }
 
   onChange(key, val) {
@@ -43,4 +52,4 @@ class LoginForm extends Component {
   }
 }
 
-export default connect(null, mapActionsToProps)(LoginForm);
+export default connect(mapStateToProps, mapActionsToProps)(LoginForm);

--- a/application/src/router/appRouter.js
+++ b/application/src/router/appRouter.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Main, Login, OrderForm, ViewOrders } from '../components';
+import AuthRoute from './route-guard/authRoute'
 
 const AppRouter = (props) => {
   return (
     <Router>
       <Route path="/" exact component={Main} />
       <Route path="/login" exact component={Login} />
-      <Route path="/order" exact component={OrderForm} />
-      <Route path="/view-orders" exact component={ViewOrders} />
+      <AuthRoute path="/order" exact component={OrderForm} />
+      <AuthRoute path="/view-orders" exact component={ViewOrders} />
     </Router>
   );
 }

--- a/application/src/router/route-guard/authRoute.js
+++ b/application/src/router/route-guard/authRoute.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Route, Redirect } from 'react-router-dom';
+
+const mapStateToProps = (state) => ({
+    auth: state.auth,
+})
+
+const AuthRoute = ({ component: Component, auth, ...rest }) => {
+    return (
+        <Route { ...rest }>
+            { auth.token 
+                ? <Component />
+                : <Redirect to={"/login"} />
+            }
+        </Route>
+    )
+}
+
+export default connect(mapStateToProps, null)(AuthRoute);


### PR DESCRIPTION
Closes Shift3#21 

# Changes
1. Created an `AuthRoute` component that redirects to login page if user is not logged in
2. Guard `/order` and `/view-orders` paths using AuthRoute
3. Modify `LoginForm` to check for auth token before calling `onLogin` callback

# Purpose
The `AuthRoute` is added to prevent users from navigating to the order form or view orders page without properly logging in.