### PR TITLE
Feat: Add "edit" and "delete" order functionality

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -5,6 +5,7 @@ import { SERVER_IP } from '../../private';
 import './orderForm.css';
 
 const ADD_ORDER_URL = `${SERVER_IP}/api/add-order`
+const EDIT_ORDER_URL = `${SERVER_IP}/api/edit-order`
 
 const mapStateToProps = (state) => ({
     auth: state.auth,
@@ -13,9 +14,12 @@ const mapStateToProps = (state) => ({
 class OrderForm extends Component {
     constructor(props) {
         super(props);
+
+        const { order } = this.props.location;
+
         this.state = {
-            order_item: "",
-            quantity: "1"
+            order_item: order ? order.order_item : "",
+            quantity: order ? order.quantity : 1
         }
     }
 
@@ -30,23 +34,45 @@ class OrderForm extends Component {
     submitOrder(event) {
         event.preventDefault();
         if (this.state.order_item === "") return;
-        fetch(ADD_ORDER_URL, {
-            method: 'POST',
-            body: JSON.stringify({
-                order_item: this.state.order_item,
-                quantity: this.state.quantity,
-                ordered_by: this.props.auth.email || 'Unknown!',
-            }),
-            headers: {
-                'Content-Type': 'application/json'
-            }
-        })
-        .then(res => res.json())
-        .then(response => console.log("Success", JSON.stringify(response)))
-        .catch(error => console.error(error));
+
+        if (this.props.location.order) {
+            fetch(EDIT_ORDER_URL, {
+                method: 'POST',
+                body: JSON.stringify({
+                    id: this.props.location.order._id,
+                    order_item: this.state.order_item,
+                    quantity: this.state.quantity,
+                    ordered_by: this.props.auth.email || 'Unknown!',
+                }),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            })
+            .then(res => res.json())
+            .then(response => console.log("Success", JSON.stringify(response)))
+            .catch(error => console.error(error));
+        } else {
+            fetch(ADD_ORDER_URL, {
+                method: 'POST',
+                body: JSON.stringify({
+                    order_item: this.state.order_item,
+                    quantity: this.state.quantity,
+                    ordered_by: this.props.auth.email || 'Unknown!',
+                }),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            })
+            .then(res => res.json())
+            .then(response => console.log("Success", JSON.stringify(response)))
+            .catch(error => console.error(error));
+        }
     }
 
     render() {
+
+        const { order } = this.props.location;
+
         return (
             <Template>
                 <div className="form-wrapper">
@@ -72,7 +98,13 @@ class OrderForm extends Component {
                             <option value="5">5</option>
                             <option value="6">6</option>
                         </select>
-                        <button type="button" className="order-btn" onClick={(event) => this.submitOrder(event)}>Order It!</button>
+                        <button 
+                            type="button" 
+                            className="order-btn" 
+                            onClick={(event) => this.submitOrder(event)}
+                        >
+                            { order ? 'Update Order' : 'Order It!' }
+                        </button>
                     </form>
                 </div>
             </Template>

--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -35,38 +35,28 @@ class OrderForm extends Component {
         event.preventDefault();
         if (this.state.order_item === "") return;
 
-        if (this.props.location.order) {
-            fetch(EDIT_ORDER_URL, {
-                method: 'POST',
-                body: JSON.stringify({
-                    id: this.props.location.order._id,
-                    order_item: this.state.order_item,
-                    quantity: this.state.quantity,
-                    ordered_by: this.props.auth.email || 'Unknown!',
-                }),
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            })
-            .then(res => res.json())
-            .then(response => console.log("Success", JSON.stringify(response)))
-            .catch(error => console.error(error));
-        } else {
-            fetch(ADD_ORDER_URL, {
-                method: 'POST',
-                body: JSON.stringify({
-                    order_item: this.state.order_item,
-                    quantity: this.state.quantity,
-                    ordered_by: this.props.auth.email || 'Unknown!',
-                }),
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            })
-            .then(res => res.json())
-            .then(response => console.log("Success", JSON.stringify(response)))
-            .catch(error => console.error(error));
+        const { order } = this.props.location;
+        const API_URL = order ? EDIT_ORDER_URL : ADD_ORDER_URL;
+        const orderDetails = {
+            order_item: this.state.order_item,
+            quantity: this.state.quantity,
+            ordered_by: this.props.auth.email || 'Unknown!'
+        };
+
+        if (order) {
+            orderDetails.id = order._id;
         }
+
+        fetch(API_URL, {
+            method: 'POST',
+            body: JSON.stringify(orderDetails),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(res => res.json())
+        .then(response => console.log("Success", JSON.stringify(response)))
+        .catch(error => console.error(error));
     }
 
     render() {

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import { Template } from '../../components';
 import { SERVER_IP } from '../../private';
 import './viewOrders.css';
@@ -55,7 +56,9 @@ class ViewOrders extends Component {
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">
-                                     <button className="btn btn-success">Edit</button>
+                                    <Link to={{pathname: '/order', order}}>
+                                        <button className="btn btn-success">Edit</button>
+                                    </Link>
                                     <button className="btn btn-danger" onClick={() => this.deleteOrder(order._id)}>Delete</button>
                                  </div>
                             </div>

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -3,6 +3,8 @@ import { Template } from '../../components';
 import { SERVER_IP } from '../../private';
 import './viewOrders.css';
 
+const DELETE_ORDER_URL = `${SERVER_IP}/api/delete-order`;
+
 class ViewOrders extends Component {
     state = {
         orders: []
@@ -18,6 +20,22 @@ class ViewOrders extends Component {
                     console.log('Error getting orders');
                 }
             });
+    }
+
+    deleteOrder(orderId) {
+        fetch(DELETE_ORDER_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                id: orderId
+            })
+        }).then(res => {
+            this.setState(prev => ({
+                orders: prev.orders.filter(order => order._id !== orderId)
+            }))
+        }).catch(error => console.log(error))
     }
 
     render() {
@@ -38,7 +56,7 @@ class ViewOrders extends Component {
                                  </div>
                                  <div className="col-md-4 view-order-right-col">
                                      <button className="btn btn-success">Edit</button>
-                                     <button className="btn btn-danger">Delete</button>
+                                    <button className="btn btn-danger" onClick={() => this.deleteOrder(order._id)}>Delete</button>
                                  </div>
                             </div>
                         );


### PR DESCRIPTION
Closes Shift3#15

# Changes 
1. On delete button clicked, delete make API call to delete order
2. On edit button clicked, navigate to OrderForm and pass order to be edited as object on location prop
3. Modify OrderForm to handle both adding a new order and editing an existing order

# Purpose
The existing components were modified to add "edit" and "delete" functionality while leveraging existing components as much as possible instead of creating new components.