### PR TITLE
Feat: Retrieve user from Redux and include in Order Form

### DIFF
--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
Closes Shift3#17

# Changes
1. Change `authReducer` to grab the email from the payload

# Purpose
The current implementation of the reducer is incorrectly setting email equal to `payload.login` in the returned object. This incorrectly sets that logged in user's email to undefined.